### PR TITLE
feat(QgsLocatorWidget): add setPlaceholderText for lineedit

### DIFF
--- a/python/PyQt6/gui/auto_generated/locator/qgslocatorwidget.sip.in
+++ b/python/PyQt6/gui/auto_generated/locator/qgslocatorwidget.sip.in
@@ -44,6 +44,13 @@ widget to customize the searches performed by its :py:func:`~QgsLocatorWidget.lo
 as prioritizing results which are near the current canvas extent.
 %End
 
+    void setPlaceholderText( const QString  &text );
+%Docstring
+Set placeholder ``text`` for the line edit.
+
+.. versionadded:: 3.36
+%End
+
   public slots:
 
     void search( const QString &string );

--- a/python/gui/auto_generated/locator/qgslocatorwidget.sip.in
+++ b/python/gui/auto_generated/locator/qgslocatorwidget.sip.in
@@ -44,6 +44,13 @@ widget to customize the searches performed by its :py:func:`~QgsLocatorWidget.lo
 as prioritizing results which are near the current canvas extent.
 %End
 
+    void setPlaceholderText( const QString  &text );
+%Docstring
+Set placeholder ``text`` for the line edit.
+
+.. versionadded:: 3.36
+%End
+
   public slots:
 
     void search( const QString &string );

--- a/src/gui/locator/qgslocatorwidget.cpp
+++ b/src/gui/locator/qgslocatorwidget.cpp
@@ -150,6 +150,11 @@ void QgsLocatorWidget::setMapCanvas( QgsMapCanvas *canvas )
   }
 }
 
+void QgsLocatorWidget::setPlaceholderText( const QString &text )
+{
+  mLineEdit->setPlaceholderText( text );
+}
+
 void QgsLocatorWidget::search( const QString &string )
 {
   window()->activateWindow(); // window must also be active - otherwise floating docks can steal keystrokes

--- a/src/gui/locator/qgslocatorwidget.h
+++ b/src/gui/locator/qgslocatorwidget.h
@@ -66,6 +66,12 @@ class GUI_EXPORT QgsLocatorWidget : public QWidget
      */
     void setMapCanvas( QgsMapCanvas *canvas );
 
+    /**
+     * \brief Set placeholder \a text for the line edit.
+     * \since QGIS 3.36
+     */
+    void setPlaceholderText( const QString  &text );
+
   public slots:
 
     /**


### PR DESCRIPTION
## Description

I need to add a `QgsLocatorWidget` in a plugin for specific search and use of 2 widgets.

This PR add a new function `setPlaceholderText` to be able to change the placeholderText.

Here is a screenshot of the result :

![image](https://github.com/jmkerloch/QGIS/assets/53606373/dd4f9e82-0c31-4f5d-a788-8b2a6b769a4e)

